### PR TITLE
fix(gemini): align provider with actual Gemini CLI interface

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -3,6 +3,8 @@ environments:
   ci:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
@@ -244,6 +246,8 @@ environments:
   ci-minimal:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
@@ -466,6 +470,8 @@ environments:
   default:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
@@ -670,6 +676,8 @@ environments:
   dev:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
@@ -726,7 +734,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-cli-0.0.16-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-core-0.124.4-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fastmcp-2.14.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.20.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/frozenlist-1.7.0-pyhf298e5d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.12-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.45-pyhff2d567_0.conda
@@ -941,6 +949,8 @@ environments:
   quality:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
@@ -1165,6 +1175,8 @@ environments:
   quality-ci:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
@@ -1406,6 +1418,8 @@ environments:
   quality-extended:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
@@ -1458,7 +1472,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-cli-0.0.16-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-core-0.124.4-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fastmcp-2.14.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.20.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/frozenlist-1.7.0-pyhf298e5d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.12-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.45-pyhff2d567_0.conda
@@ -1657,6 +1671,8 @@ environments:
   quality-full:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
@@ -1713,7 +1729,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-cli-0.0.16-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-core-0.124.4-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fastmcp-2.14.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.20.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/frozenlist-1.7.0-pyhf298e5d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.12-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.45-pyhff2d567_0.conda
@@ -2552,14 +2568,14 @@ packages:
   license_family: APACHE
   size: 283914
   timestamp: 1765979770082
-- conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.20.0-pyhd8ed1ab_0.conda
-  sha256: 19025a4078ff3940d97eb0da29983d5e0deac9c3e09b0eabf897daeaf9d1114e
-  md5: 66b8b26023b8efdf8fcb23bac4b6325d
+- conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.20.3-pyhd8ed1ab_0.conda
+  sha256: 8b90dc21f00167a7e58abb5141a140bdb31a7c5734fe1361b5f98f4a4183fd32
+  md5: 2cfaaccf085c133a477f0a7a8657afe9
   depends:
   - python >=3.10
   license: Unlicense
-  size: 17976
-  timestamp: 1759948208140
+  size: 18661
+  timestamp: 1768022315929
 - conda: https://conda.anaconda.org/conda-forge/noarch/frozenlist-1.7.0-pyhf298e5d_0.conda
   sha256: d065c6c76ba07c148b07102f89fd14e39e4f0b2c022ad671bbef8fda9431ba1b
   md5: 3998c9592e3db2f6809e4585280415f4

--- a/pixi.lock
+++ b/pixi.lock
@@ -811,7 +811,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lupa-2.6-py312lua54h1289d80_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markupsafe-3.0.3-pyh7db6752_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/marshmallow-4.1.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/marshmallow-4.2.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mcp-1.23.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/memory_profiler-0.61.0-pyhcf101f3_1.conda
@@ -1547,7 +1547,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lupa-2.6-py312lua54h1289d80_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markupsafe-3.0.3-pyh7db6752_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/marshmallow-4.1.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/marshmallow-4.2.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mcp-1.23.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mkl-2024.2.2-ha770c72_17.conda
@@ -1806,7 +1806,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lupa-2.6-py312lua54h1289d80_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markupsafe-3.0.3-pyh7db6752_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/marshmallow-4.1.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/marshmallow-4.2.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mcp-1.23.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mkl-2024.2.2-ha770c72_17.conda
@@ -3489,16 +3489,17 @@ packages:
   license_family: BSD
   size: 15499
   timestamp: 1759055275624
-- conda: https://conda.anaconda.org/conda-forge/noarch/marshmallow-4.1.1-pyhd8ed1ab_0.conda
-  sha256: 8d4461dfebe08bec389c8e1badd28908034563458bba6d2867e5548b11df1788
-  md5: f0adf69e89150cc9e187c017d72544c6
+- conda: https://conda.anaconda.org/conda-forge/noarch/marshmallow-4.2.1-pyhcf101f3_0.conda
+  sha256: 6ebfd001138a2ca50ea5e65199dcf5a106a90a25ca39acb3a40a4a74563ea317
+  md5: 7851e91be3e56374ecdb8762e9eb81cf
   depends:
-  - backports-datetime-fromisoformat
   - python >=3.10
+  - backports-datetime-fromisoformat
   - typing_extensions
+  - python
   license: MIT AND BSD-3-Clause
-  size: 90925
-  timestamp: 1765020641216
+  size: 97988
+  timestamp: 1769335830763
 - conda: https://conda.anaconda.org/conda-forge/noarch/mcp-1.23.3-pyhd8ed1ab_0.conda
   sha256: 092c1df2d5cbdc03c78b25c1f9d54b4e0416c5a8f2de049a30501b2cc700dd74
   md5: 7e7c21d35ec98bc90f80e8d899175393

--- a/src/mcp_server_llm_cli_runner/lean_mcp_interface.py
+++ b/src/mcp_server_llm_cli_runner/lean_mcp_interface.py
@@ -1,5 +1,4 @@
-"""
-Lean MCP Interface for LLM CLI Runner - Dynamic Tool Discovery.
+"""Lean MCP Interface for LLM CLI Runner - Dynamic Tool Discovery.
 
 This module implements the meta-tool pattern to reduce context consumption
 while exposing LLM CLI operations through multiple providers (Gemini, OpenAI, LLaMA).
@@ -11,6 +10,7 @@ Meta-Tool Pattern:
 - Zero functionality loss with massive context savings
 """
 
+import asyncio
 import logging
 from typing import Any
 
@@ -20,8 +20,7 @@ logger = logging.getLogger(__name__)
 
 
 class LeanMCPInterface:
-    """
-    Lean MCP Interface implementing the meta-tool pattern for dynamic tool discovery.
+    """Lean MCP Interface implementing the meta-tool pattern for dynamic tool discovery.
 
     Exposes only 3 compact meta-tools (~500 tokens) with on-demand discovery
     instead of verbose tool definitions.
@@ -36,15 +35,34 @@ class LeanMCPInterface:
         self.config_manager = config_manager
         self.app = FastMCP("llm-cli-runner")
 
+        # Initialize provider instances
+        self._providers: dict[str, Any] = {}
+        self._init_providers()
+
         # Tool registry: maps tool names to their implementations and metadata
         self.tool_registry = self._build_tool_registry()
 
         # Setup the 3 meta-tools
         self._setup_meta_tools()
 
+    def _init_providers(self) -> None:
+        """Initialize available provider instances."""
+        enabled = self.config_manager.get_enabled_providers()
+
+        if "gemini" in enabled:
+            try:
+                # Lazy import to avoid circular dependency
+                from mcp_server_llm_cli_runner.providers.gemini import GeminiProvider
+
+                self._providers["gemini"] = GeminiProvider()
+                logger.info("Initialized Gemini provider")
+            except Exception as e:
+                logger.warning(f"Failed to initialize Gemini provider: {e}")
+
+        # TODO: Add other providers (llama, openai) as they are implemented
+
     def _build_tool_registry(self) -> dict[str, dict[str, Any]]:
-        """
-        Build comprehensive tool registry with metadata for dynamic discovery.
+        """Build comprehensive tool registry with metadata for dynamic discovery.
 
         Each tool entry contains:
         - implementation: The actual function
@@ -138,7 +156,7 @@ class LeanMCPInterface:
         return registry
 
     # Tool implementations
-    def _llm_complete(
+    async def _llm_complete(
         self,
         prompt: str,
         provider: str = "llama",
@@ -149,7 +167,7 @@ class LeanMCPInterface:
     ) -> dict[str, Any]:
         """Execute LLM completion."""
         try:
-            # Get provider instance
+            # Check if provider is available
             providers = self.config_manager.get_enabled_providers()
             if provider not in providers:
                 return {
@@ -157,18 +175,41 @@ class LeanMCPInterface:
                     "available_providers": providers,
                 }
 
-            # For now, return a mock response
-            # TODO: Integrate with actual provider implementation
+            # Check if provider is initialized
+            if provider not in self._providers:
+                return {
+                    "error": f"Provider '{provider}' not initialized",
+                    "available_providers": list(self._providers.keys()),
+                }
+
+            # Lazy import to avoid circular dependency
+            from mcp_server_llm_cli_runner.core.models import LLMRequest
+
+            # Create LLM request
+            # Note: stream is handled separately via stream_generate()
+            request = LLMRequest(
+                prompt=prompt,
+                model=model,
+                temperature=temperature,
+                max_tokens=max_tokens or 1000,
+                system_prompt=None,
+            )
+
+            # Get provider instance and execute
+            provider_instance = self._providers[provider]
+
+            # Await the async generate method
+            response = await provider_instance.generate(request)
+
             return {
                 "provider": provider,
-                "model": model or "default",
-                "prompt": prompt,
-                "completion": f"[Mock response from {provider}]",
-                "metadata": {
-                    "temperature": temperature,
-                    "max_tokens": max_tokens,
-                    "stream": stream,
-                },
+                "model": response.model,
+                "completion": response.content,
+                "success": response.success,
+                "tokens_used": response.tokens_used,
+                "cost": response.cost,
+                "response_time_ms": response.response_time_ms,
+                "metadata": response.metadata,
             }
         except Exception as e:
             logger.error(f"Error in llm_complete: {e}")
@@ -210,8 +251,7 @@ class LeanMCPInterface:
             description="Discover llm-cli-runner tools (3 total) for LLM completions and provider management. USE WHEN: running LLM queries, checking providers, multi-provider access"
         )
         def discover_tools(pattern: str = "") -> dict[str, Any]:
-            """
-            Get available tools with minimal context consumption.
+            """Get available tools with minimal context consumption.
 
             Args:
                 pattern: Filter by name pattern (substring match, empty string for all tools)
@@ -240,16 +280,13 @@ class LeanMCPInterface:
                 "total_tools": len(self.tool_registry),
                 "filtered_count": len(tools),
                 "domains": list(
-                    set(
-                        info.get("domain", "llm")
-                        for info in self.tool_registry.values()
-                    )
+                    {info.get("domain", "llm") for info in self.tool_registry.values()}
                 ),
                 "complexity_levels": list(
-                    set(
+                    {
                         info.get("complexity", "focused")
                         for info in self.tool_registry.values()
-                    )
+                    }
                 ),
             }
 
@@ -257,8 +294,7 @@ class LeanMCPInterface:
             description="Get full specification for specific llm-cli-runner tool including schema and examples. USE WHEN: need parameter details for LLM/provider tools before execution"
         )
         def get_tool_spec(tool_name: str) -> dict[str, Any]:
-            """
-            Get full specification for specific tool including schema and examples.
+            """Get full specification for specific tool including schema and examples.
 
             Args:
                 tool_name: Name of tool to get specification for
@@ -286,9 +322,10 @@ class LeanMCPInterface:
         @self.app.tool(
             description="Execute llm-cli-runner tool with parameters. Supports LLM completions, provider queries, configuration. USE WHEN: executing LLM queries, checking provider status"
         )
-        def execute_tool(tool_name: str, parameters: dict[str, Any]) -> dict[str, Any]:
-            """
-            Execute tool with parameters using dynamic dispatch.
+        async def execute_tool(
+            tool_name: str, parameters: dict[str, Any]
+        ) -> dict[str, Any]:
+            """Execute tool with parameters using dynamic dispatch.
 
             Args:
                 tool_name: Name of tool to execute
@@ -308,8 +345,11 @@ class LeanMCPInterface:
             tool_func = tool_info["implementation"]
 
             try:
-                # Execute tool with parameters
+                # Execute tool with parameters (handle both sync and async)
                 result = tool_func(**parameters)
+                # If result is a coroutine, await it
+                if asyncio.iscoroutine(result):
+                    result = await result
                 return {"tool": tool_name, "status": "success", "result": result}
             except Exception as e:
                 logger.error(f"Error executing {tool_name}: {e}")
@@ -321,8 +361,7 @@ class LeanMCPInterface:
 
 
 def create_lean_interface(config_manager: Any) -> FastMCP:
-    """
-    Create a lean MCP interface with minimal context consumption.
+    """Create a lean MCP interface with minimal context consumption.
 
     Args:
         config_manager: Initialized configuration manager

--- a/src/mcp_server_llm_cli_runner/providers/gemini.py
+++ b/src/mcp_server_llm_cli_runner/providers/gemini.py
@@ -185,10 +185,33 @@ class GeminiProvider(LLMProvider):
 
             # Calculate metrics
             response_time = time.time() - start_time
-            tokens_used = self._estimate_tokens(
-                request.prompt,
-                result.get("content", ""),
-            )
+
+            # Extract response content (Gemini CLI uses "response" field, not "content")
+            response_content = result.get("response", "")
+
+            # Extract actual token counts from stats if available
+            # Structure: stats.models.[model_name].tokens.{prompt, candidates, total}
+            stats = result.get("stats", {})
+            models_stats = stats.get("models", {})
+
+            # Find the model stats (could be under any model name)
+            actual_tokens = None
+            for model_stats in models_stats.values():
+                tokens_info = model_stats.get("tokens", {})
+                if tokens_info:
+                    actual_tokens = {
+                        "prompt": tokens_info.get("prompt", 0),
+                        "completion": tokens_info.get("candidates", 0),
+                        "total": tokens_info.get("total", 0),
+                    }
+                    break
+
+            # Use actual tokens if available, otherwise estimate
+            if actual_tokens:
+                tokens_used = actual_tokens["total"]
+            else:
+                tokens_used = self._estimate_tokens(request.prompt, response_content)
+
             cost = self._calculate_cost(tokens_used, model)
 
             # Track usage
@@ -200,7 +223,7 @@ class GeminiProvider(LLMProvider):
 
             # Create response
             response = LLMResponse(
-                content=result.get("content", ""),
+                content=response_content,
                 provider="gemini",
                 model=model,
                 success=True,
@@ -211,8 +234,9 @@ class GeminiProvider(LLMProvider):
                     "model": model,
                     "temperature": temperature,
                     "max_tokens": max_tokens,
-                    "cli_version": result.get("cli_version"),
-                    "usage": {
+                    "session_id": result.get("session_id"),
+                    "usage": actual_tokens
+                    or {
                         "total_tokens": tokens_used,
                         "estimated_input_tokens": self._estimate_tokens(request.prompt),
                         "estimated_output_tokens": tokens_used
@@ -301,9 +325,31 @@ class GeminiProvider(LLMProvider):
                     )
                     if line_text.strip():
                         try:
+                            # Gemini stream-json emits events: init, message, tool_use,
+                            # tool_result, error, result
                             chunk_data = json.loads(line_text.strip())
-                            content = chunk_data.get("content", "")
-                            is_final = chunk_data.get("final", False)
+                            event_type = chunk_data.get("type", "")
+
+                            # Extract content based on event type
+                            content = ""
+                            is_final = False
+
+                            if event_type == "message":
+                                # Message events contain partial response text
+                                content = chunk_data.get("content", "")
+                            elif event_type == "result":
+                                # Result event is the final response
+                                content = chunk_data.get("response", "")
+                                is_final = True
+                            elif event_type == "error":
+                                # Handle error events
+                                error_msg = chunk_data.get("error", {})
+                                content = f"Error: {error_msg}"
+                                is_final = True
+                            elif event_type == "init":
+                                # Init event - skip or include as metadata
+                                continue
+                            # tool_use and tool_result can be skipped for basic streaming
 
                             chunk = StreamingResponse(
                                 content=content,
@@ -311,7 +357,7 @@ class GeminiProvider(LLMProvider):
                                 model=model,
                                 is_final=is_final,
                                 chunk_index=chunk_index,
-                                metadata=chunk_data,
+                                metadata={"event_type": event_type, **chunk_data},
                             )
 
                             chunks.append(chunk)
@@ -508,13 +554,21 @@ class GeminiProvider(LLMProvider):
         Args:
             prompt: Text prompt
             model: Model to use
-            temperature: Sampling temperature
-            max_tokens: Maximum tokens
-            system_prompt: Optional system prompt
+            temperature: Sampling temperature (stored in metadata, not passed to CLI)
+            max_tokens: Maximum tokens (stored in metadata, not passed to CLI)
+            system_prompt: Optional system prompt (not supported by CLI)
             stream: Enable streaming
 
         Returns:
             Command as list of strings
+
+        Note:
+            The Gemini CLI (geminicli.com) has limited parameter support:
+            - --model/-m: Model selection
+            - --output-format: text, json, or stream-json
+            - --prompt/-p: Inline prompt for headless mode
+            Temperature, max_tokens, and system_prompt are NOT supported
+            by the CLI and are only used for metadata/logging purposes.
 
         """
         cmd = ["gemini"]
@@ -523,27 +577,17 @@ class GeminiProvider(LLMProvider):
         if model != "gemini-1.5-flash":  # Default model
             cmd.extend(["--model", model])
 
-        # Temperature
-        if temperature != 0.7:  # Default temperature
-            cmd.extend(["--temperature", str(temperature)])
+        # Note: --temperature, --max-tokens, --system are NOT supported by Gemini CLI
+        # These parameters are kept in the signature for compatibility but not passed
 
-        # Max tokens
-        if max_tokens != 1000:  # Default max tokens
-            cmd.extend(["--max-tokens", str(max_tokens)])
-
-        # System prompt
-        if system_prompt:
-            cmd.extend(["--system", system_prompt])
-
-        # Streaming
+        # Output format (use stream-json for streaming, json otherwise)
         if stream:
-            cmd.append("--stream")
+            cmd.extend(["--output-format", "stream-json"])
+        else:
+            cmd.extend(["--output-format", "json"])
 
-        # Output format
-        cmd.extend(["--format", "json"])
-
-        # Add the prompt as the last argument
-        cmd.append(prompt)
+        # Add the prompt using -p flag for headless mode
+        cmd.extend(["-p", prompt])
 
         logger.debug("Built Gemini command", command=" ".join(cmd))
         return cmd
@@ -592,8 +636,8 @@ class GeminiProvider(LLMProvider):
                     try:
                         return json.loads(stdout_text)
                     except json.JSONDecodeError:
-                        # Fallback to plain text
-                        return {"content": stdout_text.strip(), "format": "text"}
+                        # Fallback to plain text (use "response" to match Gemini CLI JSON format)
+                        return {"response": stdout_text.strip(), "format": "text"}
                 else:
                     # Error occurred
                     error_msg = stderr_text.strip() or stdout_text.strip()

--- a/src/mcp_server_llm_cli_runner/utils/config.py
+++ b/src/mcp_server_llm_cli_runner/utils/config.py
@@ -1166,18 +1166,15 @@ class ConfigManager:
         """
         defaults = []
 
-        # Gemini provider
-        gemini_key = EnvironmentLoader.get_api_key("gemini")  # type: ignore
-        if gemini_key:
-            defaults.append(
-                {
-                    "name": "gemini",
-                    "provider_type": "gemini",
-                    "enabled": True,
-                    "api_key": gemini_key,
-                    "model_name": "gemini-pro",
-                }
-            )
+        # Gemini provider (CLI-based, no API key needed - CLI handles its own auth)
+        defaults.append(
+            {
+                "name": "gemini",
+                "provider_type": "gemini",
+                "enabled": True,
+                "model_name": "gemini-2.5-flash-lite",
+            }
+        )
 
         # Codex provider
         openai_key = EnvironmentLoader.get_api_key("openai")  # type: ignore

--- a/tests/unit/test_gemini_provider.py
+++ b/tests/unit/test_gemini_provider.py
@@ -187,7 +187,14 @@ class TestGeminiProvider:
             assert available is True
 
     def test_build_cli_command(self):
-        """Test CLI command building"""
+        """Test CLI command building.
+
+        Note: The Gemini CLI (geminicli.com) has limited parameter support:
+        - --model/-m: Model selection
+        - --output-format: text, json, or stream-json
+        - -p/--prompt: Inline prompt for headless mode
+        Temperature, max_tokens, and system_prompt are NOT supported.
+        """
         provider = GeminiProvider(
             model="gemini-pro",
             temperature=0.8,
@@ -196,22 +203,28 @@ class TestGeminiProvider:
         cmd = provider._build_command(
             prompt="Test prompt",
             model="gemini-pro",
-            temperature=0.8,
+            temperature=0.8,  # Stored in metadata but not passed to CLI
         )
 
+        # Expected command structure for actual Gemini CLI
         expected_parts = [
             "gemini",
             "--model",
             "gemini-pro",
-            "--temperature",
-            "0.8",
-            "--format",
+            "--output-format",
             "json",
+            "-p",
             "Test prompt",
         ]
 
         for part in expected_parts:
             assert part in cmd
+
+        # Ensure unsupported flags are NOT in the command
+        assert "--temperature" not in cmd
+        assert "--max-tokens" not in cmd
+        assert "--system" not in cmd
+        assert "--format" not in cmd  # Correct flag is --output-format
 
     @pytest.mark.asyncio
     async def test_generate_response_quota_exhausted(self):


### PR DESCRIPTION
Update GeminiProvider to match geminicli.com v0.21.3:
- Use --output-format (not --format) for JSON output
- Use -p flag for prompt in headless mode
- Remove unsupported: --temperature, --max-tokens, --system
- Parse response field (not content) in JSON output
- Extract tokens from stats.models structure
- Handle stream-json events for streaming

Also update filelock 3.20.0 -> 3.20.3 (CVE-2025-68146)